### PR TITLE
Vue 3 移行: Bootstrap 廃止 + 自前 CSS 化 (Phase 6)

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,8 +1,8 @@
 # Vue 3 移行 タスク一覧
 
 > **最終更新**: 2026-02-15
-> **現在のフェーズ**: フェーズ 2+3+4+5 完了（ビルド移行 + Vue コア移行 + Pinia移行 + require変換）
-> **次にやること**: フェーズ 6（Bootstrap 廃止 + 自前 CSS 化）
+> **現在のフェーズ**: フェーズ 2+3+4+5+6 完了（ビルド移行 + Vue コア移行 + Pinia移行 + require変換 + Bootstrap廃止）
+> **次にやること**: フェーズ 7（TypeScript 導入）
 
 ---
 
@@ -54,11 +54,11 @@
 - [x] 5-7. 全画像表示の動作確認（Chrome DevTools MCP で全画面確認済み）
 
 ## フェーズ 6: Bootstrap 廃止 + 自前 CSS 化
-- [ ] 6-1. 変更前のスクリーンショット撮影
-- [ ] 6-2. Bootstrap ユーティリティクラスを common.css に自前定義
-- [ ] 6-3. Bootstrap Icons を Unicode テキスト文字に置換
-- [ ] 6-4. bootstrap, bootstrap-vue, bootstrap-icons 削除
-- [ ] 6-5. デザイン比較確認（スクリーンショット比較）
+- [x] 6-1. 変更前のスクリーンショット撮影（docs/screenshots/phase6-before/）
+- [x] 6-2. Bootstrap ユーティリティクラスを common.css に自前定義（row, col-sm-*, m-*, p-*, w-*, text-*, bg-*, fs-* 等 30+クラス）
+- [x] 6-3. Bootstrap Icons を Unicode テキスト文字に置換（▶, ■, →, ↻, ⌂, ▼）
+- [x] 6-4. bootstrap, bootstrap-icons 削除（bootstrap-vue は既に未使用）
+- [x] 6-5. デザイン比較確認（docs/screenshots/phase6-after/ で比較、全画面レイアウト崩れなし）
 
 ## フェーズ 7: TypeScript 導入
 - [ ] 7-1. typescript + vue-tsc インストール
@@ -94,7 +94,7 @@
 - Battle.vue が最も複雑（require ~30箇所、setTimeout多数、DOM直接操作あり）→ require変換完了
 - GameResult.vue, Thanks.vue のテンプレート内 `this` は Vue 3 で動作しない → 削除済み
 - FreeSelect.vue は未完成（テンプレート構文エラーあり）→ 構文エラーは修正済み。移行対象外の方針は維持
-- Bootstrap Icons はドットフォントの世界観に合わせ Unicode 文字に置換（フェーズ 6 で実施予定）
-- bootstrap-vue は Vue 2 専用のため CSS import のみ削除済み（bootstrap 本体と bootstrap-icons は残存）
+- Bootstrap Icons はドットフォントの世界観に合わせ Unicode 文字に置換済み（▶, ■, →, ↻, ⌂, ▼）
+- Bootstrap 完全廃止済み（bootstrap, bootstrap-icons パッケージ削除、自前 CSS に移行）
 - Vitest + @vue/test-utils + happy-dom をフェーズ 2+3 で前倒し導入済み
 - imageLoader.js は import.meta.glob で全画像を事前ロードする方式を採用

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "action-geme",
       "version": "1.0.0",
       "dependencies": {
-        "bootstrap": "^5.2.0",
-        "bootstrap-icons": "^1.9.1",
         "pinia": "^3.0.4",
         "vue": "^3.5.28",
         "vue-router": "^4.6.4"
@@ -554,17 +552,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1323,31 +1310,6 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
-    },
-    "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
-      }
-    },
-    "node_modules/bootstrap-icons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
-      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "not ie <= 8"
   ],
   "dependencies": {
-    "bootstrap": "^5.2.0",
-    "bootstrap-icons": "^1.9.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.28",
     "vue-router": "^4.6.4"

--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -2,6 +2,12 @@
   font-family: 'dotFont';
   src: url('../font/k8x12.ttf') format('truetype');
 }
+
+/* Bootstrap reboot 相当のリセット */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 #app {
   font-family: 'dotFont', sans-serif !important;
 }
@@ -37,3 +43,54 @@
   cursor:pointer;
 }
 
+/* --- Bootstrap ユーティリティ置換 --- */
+
+/* Grid */
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}
+.col-sm-3 { width: 25%; }
+.col-sm-4 { width: 33.333%; }
+.col-sm-6 { width: 50%; }
+
+/* Margin */
+.m-auto { margin: auto; }
+.m-0 { margin: 0; }
+.m-2 { margin: 0.5rem; }
+.mt-3 { margin-top: 1rem; }
+.mt-5 { margin-top: 3rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-4 { margin-bottom: 1.5rem; }
+.ms-2 { margin-left: 0.5rem; }
+.ms-5 { margin-left: 3rem; }
+.me-2 { margin-right: 0.5rem; }
+
+/* Padding */
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 1rem; }
+.pt-2 { padding-top: 0.5rem; }
+.pt-4 { padding-top: 1.5rem; }
+.pt-5 { padding-top: 3rem; }
+
+/* Width */
+.w-25 { width: 25%; }
+.w-50 { width: 50%; }
+.w-75 { width: 75%; }
+.w-100 { width: 100%; }
+
+/* Text */
+.text-start { text-align: left; }
+.text-center { text-align: center; }
+.text-secondary { color: #6c757d; }
+
+/* Background */
+.bg-light { background-color: #f8f9fa; }
+
+/* Border */
+.border-light { border-color: #f8f9fa !important; }
+
+/* Font size */
+.fs-3 { font-size: 1.75rem; }
+.fs-4 { font-size: 1.5rem; }

--- a/src/components/Battle.vue
+++ b/src/components/Battle.vue
@@ -40,7 +40,7 @@
     </div>
     <div>
       <a class="button p-2" href="/">
-        ホームへ戻る <i class="bi bi-house-door-fill"></i>
+        ホームへ戻る <span>⌂</span>
       </a>
     </div>
   </div>

--- a/src/components/FreeSelect.vue
+++ b/src/components/FreeSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <h1><i class="bi bi-person-check-fill me-2"></i> キャラクター選択画面</h1>
+    <h1><span class="me-2">■</span> キャラクター選択画面</h1>
 
     <div class="row w-50 m-auto">
       <div class="col-sm-6">
@@ -19,17 +19,17 @@
     <div class="mt-3">
       <div v-if="!selectStatus">
         <button class="button bg-light p-2 fs-4" @click="confirmChara">
-          　このキャラクターですすむ<i class="bi bi-arrow-right ms-2"></i>　
+          　このキャラクターですすむ<span class="ms-2">→</span>
         </button>
       </div>
       <div v-if="selectStatus" class="startArea w-25 m-auto">
         <div>
           <router-link class="button startButton mb-2 fs-3" :to="`battle/${selectPlayerImgName}/1`">
-            バトルスタート <i class="bi bi-arrow-right ms-2"></i>
+            バトルスタート <span class="ms-2">→</span>
           </router-link>
         </div>
-        <div v-if="selectStatus"><a class="reSelectButton pt-4" @click="confirmChara">　<i
-          class="bi bi-arrow-clockwise me-2"></i>キャラクターを選択しなおす</a></div>
+        <div v-if="selectStatus"><a class="reSelectButton pt-4" @click="confirmChara">　<span
+          class="me-2">↻</span>キャラクターを選択しなおす</a></div>
       </div>
     </div>
     <div class="w-50 m-auto text-start pt-5 fs-3">
@@ -76,7 +76,7 @@ export default {
       // {imgName: 'haru', displayName: 'はる'},
       // ],
       selectStatus: false,
-      accordionButtonClass: "bi bi-caret-right-fill me-2",
+      accordionIcon: "▶",
       selectCharaType: 'Player',
     }
   },
@@ -94,12 +94,7 @@ export default {
       return this.selectStatus = false
     },
     openAccordion() {
-      let right = "bi bi-caret-right-fill me-2";
-      let down = "bi bi-caret-down-fill me-2";
-      if (this.accordionButtonClass == down) {
-        return this.accordionButtonClass = right;
-      }
-      return this.accordionButtonClass = down;
+      this.accordionIcon = this.accordionIcon === '▼' ? '▶' : '▼';
     },
 
   }

--- a/src/components/GameResult.vue
+++ b/src/components/GameResult.vue
@@ -5,19 +5,19 @@
         <div v-if="matchEndMessage == 'win'">
           <h1 class="resultMsg gameWinMsg">かち！！！</h1>
           <router-link class="button" :to="`/battle/${$route.params.selectPlayerImgName}/${getNextEnemyPath()}`">
-            　次の対戦へすすむ <i class="bi bi-arrow-right"></i>
+            　次の対戦へすすむ <span>→</span>
           </router-link>
         </div>
         <div v-if="matchEndMessage == 'clear'">
           <h1 class="resultMsg gameWinMsg">かち！！！</h1>
           <router-link class="button" :to="`/thanks/${matchEndMessage}`">
-            　次へ <i class="bi bi-arrow-right"></i>
+            　次へ <span>→</span>
           </router-link>
         </div>
         <div v-if="matchEndMessage == 'lose'">
           <h1 class="resultMsg gameLoseMsg">まけ・・・</h1>
           <router-link class="button" :to="`/thanks/${matchEndMessage}`">
-            　次へ <i class="bi bi-arrow-right"></i>
+            　次へ <span>→</span>
           </router-link>
         </div>
       </div>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -18,12 +18,12 @@
           </div>
         </div>
         <div class="mt-5">
-          <router-link class="button p-3 m-2 w-25" :to="`/select`"><i class="bi bi-cursor-fill me-2"></i>　チャレンジモードではじめる
+          <router-link class="button p-3 m-2 w-25" :to="`/select`"><span class="me-2">▶</span>　チャレンジモードではじめる
           </router-link>
         </div>
         <div class="mt-5 ">
           <p>↓ 近日公開</p>
-          <a class="button border-light p-3 m-2 w-25 text-secondary bg-light bg"><i class="bi bi-cursor-fill me-2"></i>フリーたいせんモードではじめる</a>
+          <a class="button border-light p-3 m-2 w-25 text-secondary bg-light"><span class="me-2">▶</span>フリーたいせんモードではじめる</a>
         </div>
       </div>
       <div class="mt-5 m-auto w-75">

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <h1><i class="bi bi-person-check-fill me-2"></i> キャラクター選択画面</h1>
+    <h1><span class="me-2">■</span> キャラクター選択画面</h1>
     <h3>選択中：{{ selectPlayerDisplayName }}</h3>
     <div class=" ">
       <img class="selectImg" :src="getImageUrl(`${selectPlayerImgName}_stand.gif`)" alt="">
@@ -10,23 +10,23 @@
     <div class="mt-3">
       <div v-if="!selectStatus">
         <button class="button bg-light p-2 fs-4" @click="confirmChara">
-          　このキャラクターですすむ<i class="bi bi-arrow-right ms-2"></i>
+          　このキャラクターですすむ<span class="ms-2">→</span>
         </button>
       </div>
       <div v-if="selectStatus" class="startArea w-25 m-auto">
         <p class="mb-2 pt-2 fs-4">3かい "かち" でゲームクリア</p>
         <div>
         <router-link class="button startButton mb-2 fs-3" :to="`battle/${selectPlayerImgName}/1`">
-          バトルスタート <i class="bi bi-arrow-right ms-2"></i>
+          バトルスタート <span class="ms-2">→</span>
         </router-link>
         </div>
-      <div v-if="selectStatus"><a  class="reSelectButton pt-4" @click="confirmChara">　<i class="bi bi-arrow-clockwise me-2"></i>キャラクターを選択しなおす</a></div>
+      <div v-if="selectStatus"><a  class="reSelectButton pt-4" @click="confirmChara">　<span class="me-2">↻</span>キャラクターを選択しなおす</a></div>
       </div>
     </div>
     <div class=" mt-5 fs-4 m-auto " style="width: 45%;">
       <details class="text-start">
         <summary @click="openAccordion">
-          <i :class="accordionButtonClass"></i> 操作方法(コマンド)
+          <span class="me-2">{{ accordionIcon }}</span> 操作方法(コマンド)
         </summary>
 
         <div class="m-auto w-100">
@@ -77,7 +77,7 @@ export default {
         {imgName: 'kuni', displayName: 'くにあき'},
       ],
       selectStatus: false,
-      accordionButtonClass: "bi bi-caret-right-fill me-2"
+      accordionIcon: "▶"
     }
   },
   methods: {
@@ -89,12 +89,7 @@ export default {
       return this.selectStatus = false
     },
     openAccordion() {
-      let right = "bi bi-caret-right-fill me-2";
-      let down = "bi bi-caret-down-fill me-2";
-      if (this.accordionButtonClass == down) {
-        return this.accordionButtonClass = right;
-      }
-      return this.accordionButtonClass = down;
+      this.accordionIcon = this.accordionIcon === '▼' ? '▶' : '▼';
     },
 
 

--- a/src/components/Thanks.vue
+++ b/src/components/Thanks.vue
@@ -25,7 +25,7 @@
       </div>
       <div>
         <a class="button p-2" href="/">
-          ホームへ戻る <i class="bi bi-house-door-fill"></i>
+          ホームへ戻る <span>⌂</span>
         </a>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,6 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router.js'
-import 'bootstrap/dist/css/bootstrap.css'
-import 'bootstrap-icons/font/bootstrap-icons.css'
 import './assets/css/common.css'
 
 const app = createApp(App)


### PR DESCRIPTION
## Summary
- Bootstrap (5.2.0) と Bootstrap Icons (1.9.1) を完全廃止し、自前 CSS に移行
- `common.css` に Bootstrap ユーティリティクラス相当を自前定義（grid, spacing, width, text, background, font-size 等 30+ クラス）
- Bootstrap Icons を Unicode テキスト文字に置換（`▶`, `■`, `→`, `↻`, `⌂`, `▼`）
- ドットフォントの世界観に合わせたテキストベースのアイコンに統一

## 変更ファイル
- `src/assets/css/common.css` - Bootstrap ユーティリティクラスの自前定義追加
- `src/main.js` - Bootstrap CSS import 削除
- `src/components/Home.vue` - アイコン置換 (`bi-cursor-fill` → `▶`)
- `src/components/Select.vue` - アイコン置換 + accordion ロジック簡素化
- `src/components/FreeSelect.vue` - 同上
- `src/components/Battle.vue` - アイコン置換 (`bi-house-door-fill` → `⌂`)
- `src/components/Thanks.vue` - 同上
- `src/components/GameResult.vue` - アイコン置換 (`bi-arrow-right` → `→`)
- `package.json` - bootstrap, bootstrap-icons 削除

## Test plan
- [x] `npm test` — 11テスト全パス
- [x] Chrome DevTools MCP で全画面スクリーンショット比較（変更前後でレイアウト崩れなし）
  - Home, Select, Battle, Thanks (clear/lose) の5画面を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)