### PR TITLE
Battle画面のスマホ対応: タッチコントロール追加

### DIFF
--- a/src/components/Battle.vue
+++ b/src/components/Battle.vue
@@ -29,7 +29,18 @@
         </div>
       </div>
     </div>
-    <div class="mt-5 fs-4 m-auto instructions-section">
+    <TouchGamepad
+      v-if="isTouchDevice && !gameResult"
+      :visible="true"
+      @move-left="leftMove"
+      @move-right="rightMove"
+      @weak-attack="onTouchWeakAttack"
+      @strong-attack="onTouchStrongAttack"
+      @guard-start="gardStart"
+      @guard-end="gardEnd"
+      @wakeup="wakeUpMove"
+    />
+    <div v-if="!isTouchDevice" class="mt-5 fs-4 m-auto instructions-section">
       <div class="m-auto w-100">
         <h3 class="text-start">操作方法(コマンド)</h3>
         <ul class="text-start">
@@ -55,7 +66,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import GameResult from "./GameResult.vue";
+import TouchGamepad from "./TouchGamepad.vue";
 import { getImageUrl } from '@/utils/imageLoader';
+import { isTouchDevice as checkTouchDevice } from '@/utils/touchDetection';
 import { usePlayerStore } from '@/stores/player'
 import { useEnemyStore } from '@/stores/enemy'
 import type { EnemyLevel } from '@/stores/enemy'
@@ -64,7 +77,8 @@ import type { PlayerName } from '@/stores/player'
 export default defineComponent({
   name: 'Battle',
   components: {
-    GameResult
+    GameResult,
+    TouchGamepad
   },
   data() {
     return {
@@ -89,7 +103,8 @@ export default defineComponent({
       playerLifePercent: 100,
       enemyLifePercent: 100,
       timers: [] as ReturnType<typeof setTimeout>[],
-      gardTimerId: null as ReturnType<typeof setTimeout> | null
+      gardTimerId: null as ReturnType<typeof setTimeout> | null,
+      isTouchDevice: false
     }
   },
   computed: {
@@ -110,6 +125,7 @@ export default defineComponent({
     window.addEventListener('resize', this.onResize);
     document.addEventListener('keyup', this.onKeyUp);
     document.addEventListener('keydown', this.onKeyDown);
+    this.isTouchDevice = checkTouchDevice();
     this.e_x = 850;
     useEnemyStore().selectEnemy(Number(this.$route.params.enemyNum) as EnemyLevel);
     usePlayerStore().selectPlayer(this.$route.params.selectPlayerImgName as PlayerName);
@@ -271,30 +287,22 @@ export default defineComponent({
       ));
 
     },
-    gardMove() {
+    gardStart() {
+      if (this.playerStatus === 'gard') return;
       this.playerImage = getImageUrl(`${this.player}_gard.gif`);
       this.attackCount = 0;
-
-      const onKeyUpHandler = () => {
-        if (this.gardTimerId !== null) {
-          clearTimeout(this.gardTimerId);
-          this.gardTimerId = null;
-        }
-        this.playerImage = getImageUrl(`${this.player}_stand.gif`);
-        this.playerStatus = '';
-      };
-
-      this.gardTimerId = setTimeout(() => {
-          this.playerImage = getImageUrl(`${this.player}_stand.gif`);
-          this.playerStatus = '';
-          document.removeEventListener('keyup', onKeyUpHandler);
-          this.gardTimerId = null;
-        }
-        , 4000
-      );
-      this.timers.push(this.gardTimerId);
-      document.addEventListener('keyup', onKeyUpHandler, { once: true });
       this.playerStatus = 'gard';
+      this.gardTimerId = setTimeout(() => this.gardEnd(), 4000);
+      this.timers.push(this.gardTimerId);
+    },
+    gardEnd() {
+      if (this.playerStatus !== 'gard') return;
+      if (this.gardTimerId !== null) {
+        clearTimeout(this.gardTimerId);
+        this.gardTimerId = null;
+      }
+      this.playerImage = getImageUrl(`${this.player}_stand.gif`);
+      this.playerStatus = '';
     },
     deadMove() {
       this.playerImage = getImageUrl(`${this.player}_dead.gif`);
@@ -459,6 +467,29 @@ export default defineComponent({
         , 800
       ));
     },
+    onTouchWeakAttack() {
+      if (this.playerStatus === 'dead' || this.playerStatus === 'damage') return;
+      this.attackCount++;
+      if (this.attackCount > 7) {
+        this.playerImage = getImageUrl(`${this.player}_dead.gif`);
+        this.playerStatus = 'damage';
+        this.timers.push(setTimeout(() => {
+          this.resetStatus();
+          this.attackCount = 0;
+        }, 2000));
+        return;
+      }
+      this.attackMove();
+    },
+    onTouchStrongAttack() {
+      if (this.playerStatus === 'dead' || this.playerStatus === 'damage') return;
+      if (!this.enterKeyEnabled) return;
+      this.enterKeyEnabled = false;
+      this.strongAttackMove();
+      this.timers.push(setTimeout(() => {
+        this.enterKeyEnabled = true;
+      }, 1300));
+    },
     onKeyUp(event: KeyboardEvent) {
       if (this.playerStatus === 'dead') {
         this.playerImage = getImageUrl(`${this.player}_dead.gif`);
@@ -473,33 +504,20 @@ export default defineComponent({
         case 'Enter':
         case ' ':
         case 'ArrowUp':
+        case 'ArrowDown':
           event.preventDefault();
       }
 
       if (this.pressedKey === ' ') {
-        this.attackCount = this.attackCount + 1;
-        if (this.attackCount > 7) {
-          this.playerImage = getImageUrl(`${this.player}_dead.gif`);
-          this.playerStatus = 'damage';
-          this.timers.push(setTimeout(() => {
-              this.resetStatus()
-              this.attackCount = 0;
-            }
-            , 2000
-          ));
-          return;
-        }
-        this.attackMove();
+        this.onTouchWeakAttack();
       }
 
-      if (this.pressedKey === 'Enter' && this.enterKeyEnabled) {
-        this.enterKeyEnabled = false;
-        this.strongAttackMove();
-        this.timers.push(setTimeout(() => {
-            this.enterKeyEnabled = true;
-          }
-          , 1300
-        ));
+      if (this.pressedKey === 'Enter') {
+        this.onTouchStrongAttack();
+      }
+
+      if (this.pressedKey === 'ArrowDown') {
+        this.gardEnd();
       }
     },
     onKeyDown(event: KeyboardEvent) {
@@ -534,8 +552,8 @@ export default defineComponent({
       }
 
       //ガードのみキーを下げたときに機能させたい
-      if (this.pressedKey === 'ArrowDown' && this.playerStatus !== 'gard') {
-        this.gardMove();
+      if (this.pressedKey === 'ArrowDown') {
+        this.gardStart();
       }
     },
     resetStatus() {
@@ -631,6 +649,22 @@ export default defineComponent({
 @media screen and (max-width: 599px) {
   .instructions-section {
     width: 95%;
+  }
+}
+
+@media (pointer: coarse) {
+  .centeringParent {
+    padding: 5px;
+    touch-action: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}
+
+@media (pointer: coarse) and (orientation: landscape) {
+  .floar-wrapper {
+    margin-bottom: 0;
   }
 }
 

--- a/src/components/TouchGamepad.vue
+++ b/src/components/TouchGamepad.vue
@@ -1,0 +1,246 @@
+<template>
+  <div v-show="visible" class="touch-gamepad">
+    <div class="gamepad-inner">
+      <!-- 左側: D-pad (十字キー) -->
+      <div class="dpad">
+        <button
+          class="dpad-btn dpad-up"
+          @touchstart.prevent="onWakeup"
+        >
+          ↑
+        </button>
+        <button
+          class="dpad-btn dpad-left"
+          @touchstart.prevent="startMoveLeft"
+          @touchend.prevent="stopMoveLeft"
+          @touchcancel.prevent="stopMoveLeft"
+        >
+          ←
+        </button>
+        <button
+          class="dpad-btn dpad-right"
+          @touchstart.prevent="startMoveRight"
+          @touchend.prevent="stopMoveRight"
+          @touchcancel.prevent="stopMoveRight"
+        >
+          →
+        </button>
+        <button
+          class="dpad-btn dpad-down"
+          @touchstart.prevent="onGuardStart"
+          @touchend.prevent="onGuardEnd"
+          @touchcancel.prevent="onGuardEnd"
+        >
+          ↓
+        </button>
+      </div>
+
+      <!-- 右側: 攻撃ボタン -->
+      <div class="attack-buttons">
+        <button
+          class="attack-btn weak-btn"
+          @touchend.prevent="$emit('weak-attack')"
+        >
+          弱
+        </button>
+        <button
+          class="attack-btn strong-btn"
+          @touchend.prevent="$emit('strong-attack')"
+        >
+          強
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'TouchGamepad',
+  props: {
+    visible: {
+      type: Boolean,
+      required: true
+    }
+  },
+  emits: [
+    'move-left',
+    'move-right',
+    'weak-attack',
+    'strong-attack',
+    'guard-start',
+    'guard-end',
+    'wakeup'
+  ],
+  data() {
+    return {
+      moveLeftTimerId: null as ReturnType<typeof setInterval> | null,
+      moveRightTimerId: null as ReturnType<typeof setInterval> | null
+    }
+  },
+  beforeUnmount() {
+    this.stopMoveLeft()
+    this.stopMoveRight()
+  },
+  methods: {
+    startMoveLeft() {
+      this.$emit('move-left')
+      this.moveLeftTimerId = setInterval(() => {
+        this.$emit('move-left')
+      }, 80)
+    },
+    stopMoveLeft() {
+      if (this.moveLeftTimerId !== null) {
+        clearInterval(this.moveLeftTimerId)
+        this.moveLeftTimerId = null
+      }
+    },
+    startMoveRight() {
+      this.$emit('move-right')
+      this.moveRightTimerId = setInterval(() => {
+        this.$emit('move-right')
+      }, 80)
+    },
+    stopMoveRight() {
+      if (this.moveRightTimerId !== null) {
+        clearInterval(this.moveRightTimerId)
+        this.moveRightTimerId = null
+      }
+    },
+    onGuardStart() {
+      this.$emit('guard-start')
+    },
+    onGuardEnd() {
+      this.$emit('guard-end')
+    },
+    onWakeup() {
+      this.$emit('wakeup')
+    }
+  }
+})
+</script>
+
+<style scoped>
+.touch-gamepad {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  height: 130px;
+  background-color: rgba(0, 0, 0, 0.4);
+  font-family: 'dotFont', sans-serif;
+}
+
+.gamepad-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+  padding: 10px 20px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* D-pad: CSS Grid 十字配置 */
+.dpad {
+  display: grid;
+  grid-template-areas:
+    ".    up   ."
+    "left .    right"
+    ".    down .";
+  grid-template-columns: 50px 50px 50px;
+  grid-template-rows: 40px 40px 40px;
+  gap: 2px;
+}
+
+.dpad-up    { grid-area: up; }
+.dpad-left  { grid-area: left; }
+.dpad-right { grid-area: right; }
+.dpad-down  { grid-area: down; }
+
+.dpad-btn {
+  min-width: 50px;
+  min-height: 40px;
+  background-color: rgba(255, 255, 255, 0.7);
+  border: none;
+  color: #222;
+  font-size: 1.2rem;
+  font-family: 'dotFont', sans-serif;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  box-shadow:
+    3px 0 black,
+    -3px 0 black,
+    0 3px black,
+    0 -3px black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dpad-btn:active {
+  background-color: rgba(200, 200, 200, 0.9);
+  box-shadow:
+    2px 0 black,
+    -2px 0 black,
+    0 2px black,
+    0 -2px black;
+}
+
+/* 攻撃ボタン */
+.attack-buttons {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.attack-btn {
+  min-width: 60px;
+  min-height: 60px;
+  border: none;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  font-family: 'dotFont', sans-serif;
+  font-weight: bold;
+  color: #fff;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  box-shadow:
+    3px 0 black,
+    -3px 0 black,
+    0 3px black,
+    0 -3px black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.weak-btn {
+  background-color: rgba(0, 180, 255, 0.8);
+}
+
+.strong-btn {
+  background-color: rgba(255, 80, 80, 0.8);
+}
+
+.attack-btn:active {
+  box-shadow:
+    2px 0 black,
+    -2px 0 black,
+    0 2px black,
+    0 -2px black;
+}
+
+.weak-btn:active {
+  background-color: rgba(0, 140, 220, 0.95);
+}
+
+.strong-btn:active {
+  background-color: rgba(220, 50, 50, 0.95);
+}
+</style>

--- a/src/components/__tests__/Battle.test.ts
+++ b/src/components/__tests__/Battle.test.ts
@@ -222,6 +222,211 @@ describe('Battle.vue', () => {
     })
   })
 
+  describe('gardStart / gardEnd - ガード状態の管理', () => {
+    it('gardStart() がガード状態を有効にする', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = ''
+      vm.attackCount = 5
+
+      vm.gardStart()
+
+      expect(vm.playerStatus).toBe('gard')
+      expect(vm.playerImage).toBe('/mock/haru_gard.gif')
+      expect(vm.attackCount).toBe(0)
+      expect(vm.gardTimerId).not.toBeNull()
+
+      wrapper.unmount()
+    })
+
+    it('gardStart() は既にガード中なら何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'gard'
+      const imageBefore = vm.playerImage
+
+      vm.gardStart()
+
+      // 画像が変更されない（gardStart内のgard.gif設定に到達しない）
+      expect(vm.playerImage).toBe(imageBefore)
+
+      wrapper.unmount()
+    })
+
+    it('gardEnd() がガード状態を解除しタイマーをクリアする', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      // まずガード開始
+      vm.gardStart()
+      expect(vm.playerStatus).toBe('gard')
+      expect(vm.gardTimerId).not.toBeNull()
+
+      // ガード解除
+      vm.gardEnd()
+
+      expect(vm.playerStatus).toBe('')
+      expect(vm.playerImage).toBe('/mock/haru_stand.gif')
+      expect(vm.gardTimerId).toBeNull()
+
+      wrapper.unmount()
+    })
+
+    it('gardEnd() はガード状態でなければ何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'attack'
+      const imageBefore = vm.playerImage
+
+      vm.gardEnd()
+
+      expect(vm.playerStatus).toBe('attack')
+      expect(vm.playerImage).toBe(imageBefore)
+
+      wrapper.unmount()
+    })
+
+    it('gardStart() の4秒タイマーで自動的に gardEnd() が呼ばれる', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.gardStart()
+      expect(vm.playerStatus).toBe('gard')
+
+      vi.advanceTimersByTime(4000)
+
+      expect(vm.playerStatus).toBe('')
+      expect(vm.playerImage).toBe('/mock/haru_stand.gif')
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('onTouchWeakAttack - 弱攻撃のタッチ操作', () => {
+    it('attackCount をインクリメントする', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.attackCount = 0
+      vi.spyOn(vm, 'attackMove').mockImplementation(() => {})
+
+      vm.onTouchWeakAttack()
+
+      expect(vm.attackCount).toBe(1)
+
+      wrapper.unmount()
+    })
+
+    it('8回目の攻撃でスタン（damage）状態になる', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.attackCount = 7
+      vi.spyOn(vm, 'attackMove').mockImplementation(() => {})
+
+      vm.onTouchWeakAttack()
+
+      expect(vm.attackCount).toBe(8)
+      expect(vm.playerStatus).toBe('damage')
+      expect(vm.playerImage).toBe('/mock/haru_dead.gif')
+
+      // 2秒後にリセットされる
+      vi.advanceTimersByTime(2000)
+      expect(vm.playerStatus).toBe('')
+      expect(vm.attackCount).toBe(0)
+
+      wrapper.unmount()
+    })
+
+    it('dead 状態では何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'dead'
+      vm.attackCount = 0
+      const attackMoveSpy = vi.spyOn(vm, 'attackMove').mockImplementation(() => {})
+
+      vm.onTouchWeakAttack()
+
+      expect(vm.attackCount).toBe(0)
+      expect(attackMoveSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    })
+
+    it('damage 状態では何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'damage'
+      vm.attackCount = 0
+      const attackMoveSpy = vi.spyOn(vm, 'attackMove').mockImplementation(() => {})
+
+      vm.onTouchWeakAttack()
+
+      expect(vm.attackCount).toBe(0)
+      expect(attackMoveSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('onTouchStrongAttack - 強攻撃のタッチ操作', () => {
+    it('enterKeyEnabled クールダウンを尊重する', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vi.spyOn(vm, 'strongAttackMove').mockImplementation(() => {})
+      vm.enterKeyEnabled = true
+
+      vm.onTouchStrongAttack()
+
+      expect(vm.enterKeyEnabled).toBe(false)
+      expect(vm.strongAttackMove).toHaveBeenCalledTimes(1)
+
+      // クールダウン中は攻撃できない
+      vm.onTouchStrongAttack()
+      expect(vm.strongAttackMove).toHaveBeenCalledTimes(1)
+
+      // 1300ms後にクールダウン解除
+      vi.advanceTimersByTime(1300)
+      expect(vm.enterKeyEnabled).toBe(true)
+
+      wrapper.unmount()
+    })
+
+    it('dead 状態では何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'dead'
+      const strongAttackSpy = vi.spyOn(vm, 'strongAttackMove').mockImplementation(() => {})
+
+      vm.onTouchStrongAttack()
+
+      expect(strongAttackSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    })
+
+    it('damage 状態では何もしない', async () => {
+      const wrapper = await mountBattle('haru', '1')
+      const vm = wrapper.vm as any
+
+      vm.playerStatus = 'damage'
+      const strongAttackSpy = vi.spyOn(vm, 'strongAttackMove').mockImplementation(() => {})
+
+      vm.onTouchStrongAttack()
+
+      expect(strongAttackSpy).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    })
+  })
+
   describe('Bug 6: enemyAutoAction() - gameResult が true で停止', () => {
     it('gameResult が true のとき enemyMove() を呼ばない', async () => {
       const wrapper = await mountBattle('haru', '1')

--- a/src/utils/touchDetection.ts
+++ b/src/utils/touchDetection.ts
@@ -1,0 +1,3 @@
+export function isTouchDevice(): boolean {
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+}


### PR DESCRIPTION
## Summary
- 仮想ゲームパッド (D-pad + 攻撃ボタン) を Battle 画面に追加
- `gardMove()` を `gardStart()` / `gardEnd()` に分割し、キーボード・タッチ両対応
- 攻撃ロジックを `onTouchWeakAttack()` / `onTouchStrongAttack()` に抽出
- タッチデバイスではキーボード操作説明を非表示、ゲームパッドを表示
- モバイル向け CSS (touch-action: none, user-select: none) 追加
- viewport meta に user-scalable=no 追加

## New files
- `src/components/TouchGamepad.vue` — 仮想ゲームパッドコンポーネント
- `src/utils/touchDetection.ts` — タッチデバイス検出ユーティリティ

## Test plan
- [x] 全テスト合格 (npx vitest run)
- [x] モバイルエミュレーション (iPhone 12 Pro landscape) でゲームパッド表示確認
- [x] デスクトップでゲームパッド非表示・キーボード操作説明表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)